### PR TITLE
Fix grammar, remove duplicates and add missing punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ if (!result.success) {
 
 ### Narrowing types
 
-Every time you have a discriminated union, you can use the discriminant to narrow the type. See few examples below.
+Every time you have a discriminated union, you can use the discriminant to narrow the type. See a few examples below.
 
 #### `PostMetadata`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pnpm add @lens-protocol/metadata zod
 ```
 
 > [!NOTE]  
-> `zod` is marked as optional peer dependency, so if you all you need is the JSON Schema definitions, you can install `@lens-protocol/metadata` without `zod`.
+> `zod` is marked as optional peer dependency, so if all you need is the JSON Schema definitions, you can install `@lens-protocol/metadata` without `zod`.
 
 ## Documentation
 
@@ -130,7 +130,7 @@ const invalid = {
 
 #### Post metadata
 
-Post metadata schema is a union of all _content_ schemas (e.g. `ArticleMetadata`, `AudioMetadata`, etc.
+Post metadata schema is a union of all _content_ schemas (e.g. `ArticleMetadata`, `AudioMetadata`, etc.).
 
 Use it to parse the metadata referenced by `contentURI` of Lens Post.
 
@@ -476,7 +476,7 @@ import {
 ```
 
 > [!NOTE]
-> If you find yourself in a position of importing from both `@lens-protocol/metadata` and `@lens-protocol/metadata/legacy` entrypoints in the same module. You can you can use ESModule aliasing to avoid conflicts: `import * as legacy from '@lens-protocol/metadata/legacy'` and then use the legacy types, enums, and parsers under `legacy.*`.
+> If you find yourself in a position of importing from both `@lens-protocol/metadata` and `@lens-protocol/metadata/legacy` entrypoints in the same module. You can use ESModule aliasing to avoid conflicts: `import * as legacy from '@lens-protocol/metadata/legacy'` and then use the legacy types, enums, and parsers under `legacy.*`.
 
 ## JSON schemas
 


### PR DESCRIPTION
1. Fixed grammar in [!NOTE] (line 51):
-  zod` is marked as optional peer dependency, so if you all you need is the JSON Schema definitions
+ zod` is marked as optional peer dependency, so if all you need is the JSON Schema definitions

Reason: Removed redundant "you" for proper grammar.

2.Added punctuation (line 133):
- Post metadata schema is a union of all _content_ schemas (e.g. `ArticleMetadata`, `AudioMetadata`, etc.
+ Post metadata schema is a union of all _content_ schemas (e.g. `ArticleMetadata`, `AudioMetadata`, etc.).

Reason: Added a period at the end of the sentence for proper punctuation.

3.Improved grammar (line 201):
- Every time you have a discriminated union, you can use the discriminant to narrow the type. See few examples below.
+ Every time you have a discriminated union, you can use the discriminant to narrow the type. See a few examples below.

Reason: Added the article "a" before "few examples" for proper grammar.

4.Removed duplication (line 479):
- You can you can use ESModule aliasing to avoid conflicts
+ You can use ESModule aliasing to avoid conflicts

Reason: Removed duplicated "you can" to fix redundancy.